### PR TITLE
Add values size and template_mode

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,5 +21,7 @@ node[:log_rotations].each do |log|
     sharedscripts   log[:sharedscripts] || false
     postrotate      log[:postrotate] unless log[:postrotate].nil?
     options log[:options] || ["missingok", "compress", "delaycompress", "copytruncate", "notifempty"]
+    template_mode   log[:template_mode] || "0644"
+    size            log[:size] || "300k"
   end
 end


### PR DESCRIPTION
Values added size and template_mode in the recipes/default.rb that wasn't possible to configure in the first version.